### PR TITLE
Improve 'micro setup' command

### DIFF
--- a/.vscode/pnpify/eslint/package.json
+++ b/.vscode/pnpify/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "7.1.0-pnpify",
+  "version": "7.2.0-pnpify",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/.vscode/pnpify/typescript/package.json
+++ b/.vscode/pnpify/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "3.9.4-pnpify",
+  "version": "3.9.5-pnpify",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ To start a `micro` project, just [start your usual yarn project](https://yarnpkg
 yarn init
 ```
 
+Setup `yarn` so that `yarn@2.x` is used for the project, as described at [`yarn` docs](https://yarnpkg.com/getting-started/install)
+
+```sh
+yarn set version berry
+```
+
 Add packages as usual (with `yarn add` etc etc). Also, add `micro`'s CLI so managing your project becomes easier
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Setup `yarn` so that `yarn@2.x` is used for the project, as described at [`yarn`
 yarn set version berry
 ```
 
+Since we're using [Yarn PnP](https://yarnpkg.com/features/pnp) and some packages are still not completely ready for it, it's better to set `pnpMode` to `loose`
+
+```sh
+yarn config set pnpMode "loose"
+```
+
 Add packages as usual (with `yarn add` etc etc). Also, add `micro`'s CLI so managing your project becomes easier
 
 ```sh
@@ -173,7 +179,7 @@ yarn micro setup
 
 > Tip: You can run this command with a `--dry` option so the cli only prints the changes it will make to your project, instead of writting them
 
-This command will setup your Project to behave like a `micro` Project. 
+This command will setup your Project to behave like a `micro` Project.
 
 That's all for now.
 

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -23,13 +23,13 @@
   "browser": "./components/index.ts",
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-assets": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-css": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-react": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-react-intl": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-react-router": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-assets": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-css": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-react": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-react-intl": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-react-router": "^1.1.1-alpha.24",
     "vtex-tachyons": "^3.2.0",
     "webpack": "next",
     "webpack-blocks": "^2.1.0"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/micro-cli/lib/constants.ts
+++ b/packages/micro-cli/lib/constants.ts
@@ -10,3 +10,12 @@ export const PUBLIC_PATHS = {
 }
 
 export const MAX_RESPAWNS = 3
+
+export const DEFAULT_DEV_DEPENDENCIES = [
+  '@types/jest',
+  '@vtex/prettier-config',
+  'eslint',
+  'eslint-config-vtex',
+  'prettier',
+  'typescript',
+]

--- a/packages/micro-cli/lib/modules/setup/index.ts
+++ b/packages/micro-cli/lib/modules/setup/index.ts
@@ -54,17 +54,6 @@ const main = async ({ dry, d }: Options) => {
     return
   }
 
-  // Setup the project to use yarn@2.x
-  // https://yarnpkg.com/getting-started/install
-  args = ['set', 'version', 'berry']
-
-  console.log(`📓 Setting up the project to use yarn@2.x`)
-  const yarnSetupProcess = spawn.sync(command, args, { stdio: 'inherit' })
-
-  if (yarnSetupProcess.status !== 0) {
-    console.error(`\`${command} ${args.join(' ')}\` failed`)
-  }
-
   // Setup Editor SDKs for proper TypeScript support
   // since we're using yarn PnP https://yarnpkg.com/advanced/editor-sdks
   args = ['dlx', '@yarnpkg/pnpify', '--sdk']

--- a/packages/micro-cli/lib/modules/setup/index.ts
+++ b/packages/micro-cli/lib/modules/setup/index.ts
@@ -1,10 +1,12 @@
 import { join } from 'path'
 
 import { outputFile, readJSON } from 'fs-extra'
+import spawn from 'cross-spawn'
 
 import { genManifest, genTSConfig, PackageStructure } from '@vtex/micro-core'
 
 import { prettyLog } from '../../common/print'
+import { DEFAULT_DEV_DEPENDENCIES } from '../../constants'
 
 interface Options {
   dry?: boolean
@@ -19,8 +21,8 @@ const main = async ({ dry, d }: Options) => {
   const manifestPath = join(projectPath, PackageStructure.manifest)
   const tsconfigPath = join(projectPath, PackageStructure.tsconfig)
 
-  const originalManifest = await readJSON(manifestPath).catch(() => { })
-  const originalTSConfig = await readJSON(tsconfigPath).catch(() => { })
+  const originalManifest = await readJSON(manifestPath).catch(() => {})
+  const originalTSConfig = await readJSON(tsconfigPath).catch(() => {})
 
   const manifest = genManifest(originalManifest)
   const tsconfig = genTSConfig(originalTSConfig)
@@ -34,10 +36,10 @@ const main = async ({ dry, d }: Options) => {
     return
   }
 
-  console.log('📓 Writting new manifest file for your project')
+  console.log('📓 Writing new manifest file for your project')
   await outputFile(manifestPath, JSON.stringify(manifest, null, 2))
 
-  console.log('📓 Writting new tsconfig file for your project')
+  console.log('📓 Writing new tsconfig file for your project')
   await outputFile(tsconfigPath, JSON.stringify(tsconfig, null, 2))
 
   // Should we support NPM in the future?

--- a/packages/micro-cli/lib/modules/setup/index.ts
+++ b/packages/micro-cli/lib/modules/setup/index.ts
@@ -11,10 +11,6 @@ interface Options {
   d?: boolean
 }
 
-// TODO: we should also:
-//  - yarn add typescript --dev
-//  - yarn add eslint --dev
-//  - yarn dlx @yarnpkg/pnpify --sdk # to setup vscode
 const main = async ({ dry, d }: Options) => {
   const dryRun = dry ?? d
 
@@ -23,8 +19,8 @@ const main = async ({ dry, d }: Options) => {
   const manifestPath = join(projectPath, PackageStructure.manifest)
   const tsconfigPath = join(projectPath, PackageStructure.tsconfig)
 
-  const originalManifest = await readJSON(manifestPath).catch(() => {})
-  const originalTSConfig = await readJSON(tsconfigPath).catch(() => {})
+  const originalManifest = await readJSON(manifestPath).catch(() => { })
+  const originalTSConfig = await readJSON(tsconfigPath).catch(() => { })
 
   const manifest = genManifest(originalManifest)
   const tsconfig = genTSConfig(originalTSConfig)
@@ -43,6 +39,44 @@ const main = async ({ dry, d }: Options) => {
 
   console.log('📓 Writting new tsconfig file for your project')
   await outputFile(tsconfigPath, JSON.stringify(tsconfig, null, 2))
+
+  // Should we support NPM in the future?
+  const command = 'yarn'
+  let args = ['add', '-D', ...DEFAULT_DEV_DEPENDENCIES]
+
+  console.log(`📓 Installing devDependencies using ${command}`)
+  const devDependenciesInstallProcess = spawn.sync(command, args, {
+    stdio: 'inherit',
+  })
+
+  if (devDependenciesInstallProcess.status !== 0) {
+    console.error(`\`${command} ${args.join(' ')}\` failed`)
+    return
+  }
+
+  // Setup the project to use yarn@2.x
+  // https://yarnpkg.com/getting-started/install
+  args = ['set', 'version', 'berry']
+
+  console.log(`📓 Setting up the project to use yarn@2.x`)
+  const yarnSetupProcess = spawn.sync(command, args, { stdio: 'inherit' })
+
+  if (yarnSetupProcess.status !== 0) {
+    console.error(`\`${command} ${args.join(' ')}\` failed`)
+  }
+
+  // Setup Editor SDKs for proper TypeScript support
+  // since we're using yarn PnP https://yarnpkg.com/advanced/editor-sdks
+  args = ['dlx', '@yarnpkg/pnpify', '--sdk']
+
+  console.log(
+    `📓 Using ${command} to setup Editor SDKs for proper TypeScript support`
+  )
+  const editorSetupProcess = spawn.sync(command, args, { stdio: 'inherit' })
+
+  if (editorSetupProcess.status !== 0) {
+    console.error(`\`${command} ${args.join(' ')}\` failed`)
+  }
 }
 
 export default main

--- a/packages/micro-cli/package.json
+++ b/packages/micro-cli/package.json
@@ -19,6 +19,7 @@
     "@vtex/micro-server": "^1.1.1-alpha.23",
     "chalk": "^4.0.0",
     "chokidar": "^3.4.0",
+    "cross-spawn": "^7.0.3",
     "findhelp": "^1.1.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@types/chalk": "^2.2.0",
     "@types/chokidar": "^2.1.3",
+    "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
     "@types/node": "^14.0.11",

--- a/packages/micro-cli/package.json
+++ b/packages/micro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-cli",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "main": "./dist/build/cjs/index.js",
   "bin": {
@@ -15,8 +15,8 @@
   "dependencies": {
     "@babel/core": "^7.9.6",
     "@types/babel__core": "^7.1.7",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
-    "@vtex/micro-server": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
+    "@vtex/micro-server": "^1.1.1-alpha.24",
     "chalk": "^4.0.0",
     "chokidar": "^3.4.0",
     "cross-spawn": "^7.0.3",

--- a/packages/micro-core/lib/package/manifest.ts
+++ b/packages/micro-core/lib/package/manifest.ts
@@ -14,8 +14,12 @@ export const BaseManifest = {
   scripts: {
     build: 'yarn run micro build',
     watch: 'yarn run micro dev',
+    test: 'yarn run micro test',
     clean: `rm -r ${MICRO_BUILD_DIR}`,
     prepublish: 'yarn build',
+  },
+  eslintConfig: {
+    extends: 'vtex',
   },
 }
 

--- a/packages/micro-core/lib/package/manifest.ts
+++ b/packages/micro-core/lib/package/manifest.ts
@@ -84,6 +84,7 @@ export const genManifest = (
     dependencies,
     devDependencies,
     peerDependencies,
+    eslintConfig: BaseManifest.eslintConfig,
     ...rest,
   }
 }

--- a/packages/micro-core/package.json
+++ b/packages/micro-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-core",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": []

--- a/packages/micro-plugin-assets/package.json
+++ b/packages/micro-plugin-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-plugin-assets",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
     "babel-merge": "^3.0.0",
     "babel-plugin-inline-json-import": "^0.3.2",
     "babel-plugin-transform-remove-imports": "^1.3.2",
@@ -28,7 +28,7 @@
     "@types/babel__core": "^7.1.7",
     "@types/node": "^14.0.11",
     "@types/webpack-blocks": "^2.0.0",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
     "typescript": "^3.9.5"
   },
   "main-federation": "./dist/build/node/micro.entrypoint.js"

--- a/packages/micro-plugin-css/package.json
+++ b/packages/micro-plugin-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-plugin-css",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -17,7 +17,7 @@
   "main": "./dist/build/cjs/index.js",
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
     "babel-merge": "^3.0.0",
     "babel-plugin-ignore-html-and-css-imports": "^0.0.2",
     "css-loader": "^3.5.3",
@@ -35,7 +35,7 @@
     "@types/optimize-css-assets-webpack-plugin": "^5.0.1",
     "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack-blocks": "^2.0.0",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
     "typescript": "^3.9.5"
   },
   "main-federation": "./dist/build/node/micro.entrypoint.js"

--- a/packages/micro-plugin-react-intl/package.json
+++ b/packages/micro-plugin-react-intl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-plugin-react-intl",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -18,8 +18,8 @@
   "sideEffects": false,
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-react": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-react": "^1.1.1-alpha.24",
     "babel-merge": "^3.0.0",
     "babel-plugin-inline-json-import": "^0.3.2",
     "babel-plugin-react-intl": "^7.5.14",
@@ -34,7 +34,7 @@
     "@types/react": "^16.9.35",
     "@types/react-intl": "^3.0.0",
     "@types/webpack-blocks": "^2.0.0",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
     "typescript": "^3.9.5"
   },
   "peerDependencies": {

--- a/packages/micro-plugin-react-router/package.json
+++ b/packages/micro-plugin-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-plugin-react-router",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -19,8 +19,8 @@
   "browser": "./components/index.ts",
   "dependencies": {
     "@babel/core": "^7.10.2",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
-    "@vtex/micro-plugin-react": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
+    "@vtex/micro-plugin-react": "^1.1.1-alpha.24",
     "babel-merge": "^3.0.0",
     "history": "^4.10.1",
     "react-in-viewport": "^1.0.0-alpha.11",
@@ -36,7 +36,7 @@
     "@types/react-dom": "^16.9.7",
     "@types/react-router-dom": "^5.1.5",
     "@types/webpack-blocks": "^2.0.0",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
     "typescript": "^3.9.5"
   },
   "peerDependencies": {

--- a/packages/micro-plugin-react/package.json
+++ b/packages/micro-plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-plugin-react",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "micro": {
     "plugins": [
@@ -29,7 +29,7 @@
     "@loadable/component": "^5.12.0",
     "@loadable/server": "^5.12.0",
     "@loadable/webpack-plugin": "^5.12.0",
-    "@vtex/micro-core": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
     "babel-loader": "^8.1.0",
     "babel-merge": "^3.0.0",
     "css-loader": "^3.5.3",
@@ -58,7 +58,7 @@
     "@types/react-dom": "^16.9.7",
     "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack-blocks": "^2.0.0",
-    "@vtex/micro-cli": "^1.1.1-alpha.23",
+    "@vtex/micro-cli": "^1.1.1-alpha.24",
     "typescript": "^3.9.5"
   }
 }

--- a/packages/micro-server/package.json
+++ b/packages/micro-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/micro-server",
-  "version": "1.1.1-alpha.23",
+  "version": "1.1.1-alpha.24",
   "license": "MIT",
   "main": "./dist/build/cjs/index.js",
   "types": "./dist/build/cjs/index.js",
@@ -11,7 +11,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@vtex/micro-core": "^1.1.1-alpha.23",
+    "@vtex/micro-core": "^1.1.1-alpha.24",
     "@yarnpkg/fslib": "^2.0.0-rc.20",
     "@yarnpkg/libzip": "^2.0.0-rc.11",
     "chalk": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,6 +2581,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cross-spawn@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@types/cross-spawn@npm:6.0.2"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3/b083a3f946a47c53c3326aaaa71b84413cec4e51344f360f24eb7783ee387221f5295905629ae2de260d83a83e847c1e806ace79944038124c64365a487c7135
+  languageName: node
+  linkType: hard
+
 "@types/deepmerge@npm:^2.2.0":
   version: 2.2.0
   resolution: "@types/deepmerge@npm:2.2.0"
@@ -3300,6 +3309,7 @@ __metadata:
     "@types/babel__core": ^7.1.7
     "@types/chalk": ^2.2.0
     "@types/chokidar": ^2.1.3
+    "@types/cross-spawn": ^6.0.2
     "@types/fs-extra": ^8.1.0
     "@types/glob": ^7.1.1
     "@types/node": ^14.0.11
@@ -3309,6 +3319,7 @@ __metadata:
     "@vtex/micro-server": ^1.1.1-alpha.22
     chalk: ^4.0.0
     chokidar: ^3.4.0
+    cross-spawn: ^7.0.3
     findhelp: ^1.1.0
     fs-extra: ^9.0.0
     glob: ^7.1.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,7 +2586,7 @@ __metadata:
   resolution: "@types/cross-spawn@npm:6.0.2"
   dependencies:
     "@types/node": "*"
-  checksum: 3/b083a3f946a47c53c3326aaaa71b84413cec4e51344f360f24eb7783ee387221f5295905629ae2de260d83a83e847c1e806ace79944038124c64365a487c7135
+  checksum: b083a3f946a47c53c3326aaaa71b84413cec4e51344f360f24eb7783ee387221f5295905629ae2de260d83a83e847c1e806ace79944038124c64365a487c7135
   languageName: node
   linkType: hard
 
@@ -3301,7 +3301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vtex/micro-cli@^1.1.1-alpha.22, @vtex/micro-cli@workspace:packages/micro-cli":
+"@vtex/micro-cli@^1.1.1-alpha.23, @vtex/micro-cli@workspace:packages/micro-cli":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-cli@workspace:packages/micro-cli"
   dependencies:
@@ -3315,8 +3315,8 @@ __metadata:
     "@types/node": ^14.0.11
     "@types/open": ^6.2.1
     "@types/ramda": ^0.27.4
-    "@vtex/micro-core": ^1.1.1-alpha.22
-    "@vtex/micro-server": ^1.1.1-alpha.22
+    "@vtex/micro-core": ^1.1.1-alpha.23
+    "@vtex/micro-server": ^1.1.1-alpha.23
     chalk: ^4.0.0
     chokidar: ^3.4.0
     cross-spawn: ^7.0.3
@@ -3335,7 +3335,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-core@^1.1.1-alpha.22, @vtex/micro-core@workspace:packages/micro-core":
+"@vtex/micro-core@^1.1.1-alpha.23, @vtex/micro-core@workspace:packages/micro-core":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-core@workspace:packages/micro-core"
   dependencies:
@@ -3366,7 +3366,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-plugin-assets@^1.1.1-alpha.22, @vtex/micro-plugin-assets@workspace:packages/micro-plugin-assets":
+"@vtex/micro-plugin-assets@^1.1.1-alpha.23, @vtex/micro-plugin-assets@workspace:packages/micro-plugin-assets":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-plugin-assets@workspace:packages/micro-plugin-assets"
   dependencies:
@@ -3374,8 +3374,8 @@ __metadata:
     "@types/babel__core": ^7.1.7
     "@types/node": ^14.0.11
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
     babel-merge: ^3.0.0
     babel-plugin-inline-json-import: ^0.3.2
     babel-plugin-transform-remove-imports: ^1.3.2
@@ -3386,7 +3386,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-plugin-css@^1.1.1-alpha.22, @vtex/micro-plugin-css@workspace:packages/micro-plugin-css":
+"@vtex/micro-plugin-css@^1.1.1-alpha.23, @vtex/micro-plugin-css@workspace:packages/micro-plugin-css":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-plugin-css@workspace:packages/micro-plugin-css"
   dependencies:
@@ -3397,8 +3397,8 @@ __metadata:
     "@types/optimize-css-assets-webpack-plugin": ^5.0.1
     "@types/terser-webpack-plugin": ^2.2.0
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
     babel-merge: ^3.0.0
     babel-plugin-ignore-html-and-css-imports: ^0.0.2
     css-loader: ^3.5.3
@@ -3412,7 +3412,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-plugin-react-intl@^1.1.1-alpha.22, @vtex/micro-plugin-react-intl@workspace:packages/micro-plugin-react-intl":
+"@vtex/micro-plugin-react-intl@^1.1.1-alpha.23, @vtex/micro-plugin-react-intl@workspace:packages/micro-plugin-react-intl":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-plugin-react-intl@workspace:packages/micro-plugin-react-intl"
   dependencies:
@@ -3422,9 +3422,9 @@ __metadata:
     "@types/react": ^16.9.35
     "@types/react-intl": ^3.0.0
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-react": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-react": ^1.1.1-alpha.23
     babel-merge: ^3.0.0
     babel-plugin-inline-json-import: ^0.3.2
     babel-plugin-react-intl: ^7.5.14
@@ -3440,7 +3440,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-plugin-react-router@^1.1.1-alpha.22, @vtex/micro-plugin-react-router@workspace:packages/micro-plugin-react-router":
+"@vtex/micro-plugin-react-router@^1.1.1-alpha.23, @vtex/micro-plugin-react-router@workspace:packages/micro-plugin-react-router":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-plugin-react-router@workspace:packages/micro-plugin-react-router"
   dependencies:
@@ -3452,9 +3452,9 @@ __metadata:
     "@types/react-dom": ^16.9.7
     "@types/react-router-dom": ^5.1.5
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-react": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-react": ^1.1.1-alpha.23
     babel-merge: ^3.0.0
     history: ^4.10.1
     react-in-viewport: ^1.0.0-alpha.11
@@ -3468,7 +3468,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-plugin-react@^1.1.1-alpha.22, @vtex/micro-plugin-react@workspace:packages/micro-plugin-react":
+"@vtex/micro-plugin-react@^1.1.1-alpha.23, @vtex/micro-plugin-react@workspace:packages/micro-plugin-react":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-plugin-react@workspace:packages/micro-plugin-react"
   dependencies:
@@ -3496,8 +3496,8 @@ __metadata:
     "@types/react-dom": ^16.9.7
     "@types/terser-webpack-plugin": ^2.2.0
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
     babel-loader: ^8.1.0
     babel-merge: ^3.0.0
     css-loader: ^3.5.3
@@ -3516,7 +3516,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vtex/micro-server@^1.1.1-alpha.22, @vtex/micro-server@workspace:packages/micro-server":
+"@vtex/micro-server@^1.1.1-alpha.23, @vtex/micro-server@workspace:packages/micro-server":
   version: 0.0.0-use.local
   resolution: "@vtex/micro-server@workspace:packages/micro-server"
   dependencies:
@@ -3530,7 +3530,7 @@ __metadata:
     "@types/pnpapi": ^0.0.0
     "@types/pretty": ^2.0.0
     "@types/webpack-dev-middleware": ^3.7.0
-    "@vtex/micro-core": ^1.1.1-alpha.22
+    "@vtex/micro-core": ^1.1.1-alpha.23
     "@yarnpkg/fslib": ^2.0.0-rc.20
     "@yarnpkg/libzip": ^2.0.0-rc.11
     chalk: ^4.1.0
@@ -5912,7 +5912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
+"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -14360,13 +14360,13 @@ fsevents@~2.1.2:
     "@types/react": ^16.9.34
     "@types/react-dom": ^16.9.7
     "@types/webpack-blocks": ^2.0.0
-    "@vtex/micro-cli": ^1.1.1-alpha.22
-    "@vtex/micro-core": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-assets": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-css": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-react": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-react-intl": ^1.1.1-alpha.22
-    "@vtex/micro-plugin-react-router": ^1.1.1-alpha.22
+    "@vtex/micro-cli": ^1.1.1-alpha.23
+    "@vtex/micro-core": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-assets": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-css": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-react": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-react-intl": ^1.1.1-alpha.23
+    "@vtex/micro-plugin-react-router": ^1.1.1-alpha.23
     css-loader: ^3.5.3
     typescript: ^3.9.5
     vtex-tachyons: ^3.2.0


### PR DESCRIPTION
#### What does this PR do?

Enhances the `micro setup` command to do a bit more work when running. Now in addition to setting adding a `micro` property in the `package.json` file, it will also: 

1. Run `yarn add -D` to install the following devDependencies:

- `@types/jest`
- `@vtex/prettier-config`
- `eslint`
- `eslint-config-vtex`
- `prettier`
- `typescript`

2. ~Run `yarn set version berry` to setup the new project to use `yarn@2.x`, as described at the [docs](https://yarnpkg.com/getting-started/install).~ Noticed this a bad idea, since `@vtex/micro-cli` only works on `yarn@2.x`, which means a user would _already_ have run `yarn set version berry`, and running it again on setup might change the `yarnPath` property and break the script execution. We should instruct the user to run `yarn set version berry` **before** installing the `micro-cli`.

3. Setup Editor SDKs (mainly for VSCode users) for proper TypeScript IDE support, as described at [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks).

The default `BaseManifest` defined by `micro-core` was updated to include a new `test` script, which runs `yarn run micro test`, and an `eslintConfig` property set to `{ extends: "vtex" }`. This means that new `micro` projects would already have `yarn test` and ESLint configurations wired up.

<img width="1521" alt="Screen Shot 2020-06-07 at 23 41 42" src="https://user-images.githubusercontent.com/27777263/83988085-9a39a600-a918-11ea-9a85-665144b55fe1.png">

<img width="1131" alt="Screen Shot 2020-06-07 at 23 42 24" src="https://user-images.githubusercontent.com/27777263/83988093-a1f94a80-a918-11ea-9f89-02aada3f9c57.png">

#### Notes

It makes more sense to merge this after https://github.com/vtex/micro/pull/20.